### PR TITLE
Configure tx_count and the heartbeat timeout via flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ are supported: `serial://<device>` where `<device>` is the serial/USB port on wh
 - `use_raw_rate`: By default the API takes the number of seconds as the rate in which to transition lights to their new level. The number of seconds is coverted to the closest rate value that UPB understands (see rate table below). For example, if a request is to transition a light to its new state in 8 seconds, the closest value that UPB supports is 6.6 seconds and that is the transition time that will be used. If the use raw rate flag is given on initializing this library then the rate value is assumed to be the UPB rate value. i.e.: not in seconds but is a value that UPB "understands".
 - `report_state`: By default the API does not ask for a state update from a device when issuing goto, fade start, or blink commands. Including this flag on startup of the library will cause a report state to be issued immediately following one of the mentioned state changing commands.
 - `no_sync`: By default when the library first starts a report state is sent to every device to synchronize the state of the UPB network with the library. This flag turns off the initial sync. This was put in place for debugging and is not expected to be used outside of that.
+- `heartbeat_timeout_sec`: Overrides the duration of idleness (no messages being received) after which the library will re-initialize the connection, possibly triggering a sync. Applies only to the `tcp` protocol, and defaults to 90 seconds. Setting the value to -1 disables this feature.
+- `tx_count`: The number of times every UPB message is transmitted (CNT portion of the control word). Defaults to 1. Setting the value to 2 may be required for networks that use a repeater.
 
 ## First use of the API
 
@@ -102,3 +104,13 @@ There is a `Makefile` in the root directory as well. The `make` command
 followed by one of the targets in the `Makefile` can be used. If you don't
 have or wish to use `make` the `Makefile` serves as examples of common
 commands that can be run.
+
+## Working with the UPB Protocol
+
+Useful information on the UPB protocol can be found in the following documents:
+  1. [UPB System Description](https://www.ipcf.org/doc/UPB_System_Description_v1.1.pdf)
+  1. [Powerline Interface Module Description](http://www.webmtn.com/webUniversity/upbDocs/PimComm1.6.pdf)
+
+Using [ser2net](https://linux.die.net/man/8/ser2net) to proxy and examine
+commands sent by [UpStart](https://pcswebstore.com/pages/upb-software) can also
+be insightful.

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -1,18 +1,18 @@
-from upb_lib.message import encode_message, create_control_word
+from upb_lib.message import MessageEncode
 from upb_lib.devices import UpbAddr
 
 
 def test_create_control_word_all_zeros():
-    assert "{:04X}".format(create_control_word(False, 0, 0, 0)) == "0000"
+    assert "{:04X}".format(MessageEncode(0)._create_control_word(False, 0, 0)) == "0000"
 
 
 def test_create_control_word_all_ones():
-    assert "{:04X}".format(create_control_word(True, 3, 7, 3)) == "E07C"
+    assert "{:04X}".format(MessageEncode(3)._create_control_word(True, 3, 7)) == "E07C"
 
 
 def test_encode_message():
     addr = UpbAddr(194, 9, 0)
     assert (
-        encode_message(0x8904, addr, 9, 0x20, bytearray([0xFF, 0xFF]))
+        MessageEncode(0)._encode_message(0x8904, addr, 9, 0x20, bytearray([0xFF, 0xFF]))
         == "8904C2090920FFFF81"  # noqa
     )

--- a/upb_lib/links.py
+++ b/upb_lib/links.py
@@ -5,14 +5,6 @@ from time import time
 
 from .const import MINIMUM_BLINK_RATE, UpbCommand
 from .elements import Addr, Element, Elements
-from .message import (
-    encode_activate_link,
-    encode_blink,
-    encode_deactivate_link,
-    encode_fade_start,
-    encode_fade_stop,
-    encode_goto,
-)
 from .util import check_dim_params, rate_to_seconds
 
 LOG = logging.getLogger(__name__)
@@ -51,12 +43,12 @@ class Link(Element):
 
     def activate(self):
         """(Helper) Activate link"""
-        self._pim.send(encode_activate_link(self._addr), False)
+        self._pim.send(self._pim.encoder.activate_link(self._addr), False)
         self.update_device_levels(UpbCommand.ACTIVATE)
 
     def deactivate(self):
         """(Helper) Deactivate link"""
-        self._pim.send(encode_deactivate_link(self._addr), False)
+        self._pim.send(self._pim.encoder.deactivate_link(self._addr), False)
         self.update_device_levels(UpbCommand.DEACTIVATE)
 
     def goto(self, brightness, rate=-1):
@@ -65,7 +57,7 @@ class Link(Element):
         brightness, rate = check_dim_params(
             brightness, rate, self._pim.flags.get("use_raw_rate")
         )
-        self._pim.send(encode_goto(self._addr, brightness, rate), False)
+        self._pim.send(self._pim.encoder.goto(self._addr, brightness, rate), False)
         self.update_device_levels(UpbCommand.GOTO, brightness, saved_rate)
 
     def fade_start(self, brightness, rate=-1):
@@ -74,12 +66,12 @@ class Link(Element):
         brightness, rate = check_dim_params(
             brightness, rate, self._pim.flags.get("use_raw_rate")
         )
-        self._pim.send(encode_fade_start(self._addr, brightness, rate), False)
+        self._pim.send(self._pim.encoder.fade_start(self._addr, brightness, rate), False)
         self.update_device_levels(UpbCommand.FADE_START, brightness, saved_rate)
 
     def fade_stop(self):
         """(Helper) Stop fading a link."""
-        self._pim.send(encode_fade_stop(self._addr), False)
+        self._pim.send(self._pim.encoder.fade_stop(self._addr), False)
         for device_link in self.devices:
             device = self._pim.devices.elements.get(device_link.device_id)
             if device:
@@ -91,7 +83,7 @@ class Link(Element):
             "unlimited_blink_rate"
         ):
             rate = MINIMUM_BLINK_RATE  # Force 1/3 of second blink rate
-        self._pim.send(encode_blink(self._addr, rate), False)
+        self._pim.send(self._pim.encoder.blink(self._addr, rate), False)
         self.update_device_levels(UpbCommand.BLINK, 100)
 
     def update_device_levels(self, upb_cmd, level=-1, rate=-1):

--- a/upb_lib/message.py
+++ b/upb_lib/message.py
@@ -78,77 +78,75 @@ class MessageDecode:
         self.call_handlers(message.msg_id, message)
 
 
-def create_control_word(link, repeater=0, ack=0, tx_cnt=0):
-    """Create a control word in UPB message."""
-    ctl = (1 if link else 0) << 15
-    ctl = ctl | (repeater << 13)
-    ctl = ctl | (ack << 4)
-    ctl = ctl | (tx_cnt << 2)
-    ctl = ctl | 0
-    return ctl
+class MessageEncode:
+    """Encodes UPB commands."""
 
+    def __init__(self, tx_count):
+        """Initialize a new MessageEncode instance."""
+        self._tx_count = tx_count
 
-def encode_message(ctl, addr, src_id, msg_code, data=""):
-    """Encode a message for the PIM, assumes data formatted"""
-    ctl = create_control_word(addr.is_link) if ctl == -1 else ctl
-    length = 7 + len(data)
-    ctl = ctl | (length << 8)
-    msg = bytearray(length)
-    msg[0:2] = ctl.to_bytes(2, byteorder="big")
-    msg[2] = addr.network_id
-    msg[3] = addr.upb_id
-    msg[4] = src_id
-    msg[5] = msg_code
-    if data:
-        msg[6 : len(data) + 6] = data
-    msg[-1] = (256 - reduce(lambda x, y: x + y, msg)) % 256  # Checksum
-    return msg.hex().upper()
+    def _create_control_word(self, link, repeater=0, ack=0):
+        """Create a control word in UPB message."""
+        ctl = (1 if link else 0) << 15
+        ctl = ctl | (repeater << 13)
+        ctl = ctl | (ack << 4)
+        ctl = ctl | (self._tx_count << 2)
+        ctl = ctl | 0
+        return ctl
 
+    def _encode_message(self, ctl, addr, src_id, msg_code, data=""):
+        """Encode a message for the PIM, assumes data formatted"""
+        ctl = self._create_control_word(addr.is_link) if ctl == -1 else ctl
+        length = 7 + len(data)
+        ctl = ctl | (length << 8)
+        msg = bytearray(length)
+        msg[0:2] = ctl.to_bytes(2, byteorder="big")
+        msg[2] = addr.network_id
+        msg[3] = addr.upb_id
+        msg[4] = src_id
+        msg[5] = msg_code
+        if data:
+            msg[6 : len(data) + 6] = data
+        msg[-1] = (256 - reduce(lambda x, y: x + y, msg)) % 256  # Checksum
+        return msg.hex().upper()
 
-def encode_activate_link(addr, ctl=-1):
-    """Activate link"""
-    return encode_message(ctl, addr, PIM_ID, UpbCommand.ACTIVATE.value)
+    def activate_link(self, addr, ctl=-1):
+        """Activate link"""
+        return self._encode_message(ctl, addr, PIM_ID, UpbCommand.ACTIVATE.value)
 
+    def deactivate_link(self, addr, ctl=-1):
+        """Activate link"""
+        return self._encode_message(ctl, addr, PIM_ID, UpbCommand.DEACTIVATE.value)
 
-def encode_deactivate_link(addr, ctl=-1):
-    """Activate link"""
-    return encode_message(ctl, addr, PIM_ID, UpbCommand.DEACTIVATE.value)
+    def _encode_common(self, ctl, addr, cmd, level, rate):
+        """Goto/fade_start, device or link"""
+        rate = int(rate)
+        args = bytearray([level])
+        if addr.is_device and addr.multi_channel:
+            args.append(0xFF if rate == -1 else rate)
+            args.append(addr.channel + 1)
+        elif rate != -1:
+            args.append(rate)
 
+        return self._encode_message(ctl, addr, PIM_ID, cmd, args)
 
-def _encode_common(ctl, addr, cmd, level, rate):
-    """Goto/fade_start, device or link"""
-    rate = int(rate)
-    args = bytearray([level])
-    if addr.is_device and addr.multi_channel:
-        args.append(0xFF if rate == -1 else rate)
-        args.append(addr.channel + 1)
-    elif rate != -1:
-        args.append(rate)
+    def goto(self, addr, level, rate, ctl=-1):
+        """Goto level, device or link"""
+        return self._encode_common(ctl, addr, UpbCommand.GOTO.value, level, rate)
 
-    return encode_message(ctl, addr, PIM_ID, cmd, args)
+    def fade_start(self, addr, level, rate, ctl=-1):
+        """Fade start level, device or link"""
+        return self._encode_common(ctl, addr, UpbCommand.FADE_START.value, level, rate)
 
+    def fade_stop(self, addr, ctl=-1):
+        """Fade stop, device or link."""
+        return self._encode_message(ctl, addr, PIM_ID, UpbCommand.FADE_STOP.value)
 
-def encode_goto(addr, level, rate, ctl=-1):
-    """Goto level, device or link"""
-    return _encode_common(ctl, addr, UpbCommand.GOTO.value, level, rate)
+    def blink(self, addr, rate, ctl=-1):
+        """Blink, device or link."""
+        args = bytearray([rate])
+        return self._encode_message(ctl, addr, PIM_ID, UpbCommand.BLINK.value, args)
 
-
-def encode_fade_start(addr, level, rate, ctl=-1):
-    """Fade start level, device or link"""
-    return _encode_common(ctl, addr, UpbCommand.FADE_START.value, level, rate)
-
-
-def encode_fade_stop(addr, ctl=-1):
-    """Fade stop, device or link."""
-    return encode_message(ctl, addr, PIM_ID, UpbCommand.FADE_STOP.value)
-
-
-def encode_blink(addr, rate, ctl=-1):
-    """Blink, device or link."""
-    args = bytearray([rate])
-    return encode_message(ctl, addr, PIM_ID, UpbCommand.BLINK.value, args)
-
-
-def encode_report_state(addr, ctl=-1):
-    """Report state message."""
-    return encode_message(ctl, addr, PIM_ID, UpbCommand.REPORT_STATE.value)
+    def report_state(self, addr, ctl=-1):
+        """Report state message."""
+        return self._encode_message(ctl, addr, PIM_ID, UpbCommand.REPORT_STATE.value)

--- a/upb_lib/message.py
+++ b/upb_lib/message.py
@@ -83,7 +83,8 @@ class MessageEncode:
 
     def __init__(self, tx_count):
         """Initialize a new MessageEncode instance."""
-        self._tx_count = tx_count
+        # Value of 00 corresponds to 1 transmit.
+        self._tx_count = tx_count - 1
 
     def _create_control_word(self, link, repeater=0, ack=0):
         """Create a control word in UPB message."""

--- a/upb_lib/upb.py
+++ b/upb_lib/upb.py
@@ -48,7 +48,7 @@ class UpbPim:
         url = self._config["url"]
         LOG.info("Connecting to UPB PIM at %s", url)
         scheme, dest, param = parse_url(url)
-        heartbeat_time = 90 if scheme == "tcp" else -1
+        heartbeat_time = self.flags.get("heartbeat", 90) if scheme == "tcp" else -1
         conn = partial(
             Connection,
             self.loop,

--- a/upb_lib/upb.py
+++ b/upb_lib/upb.py
@@ -25,7 +25,7 @@ class UpbPim:
         self.flags = parse_flags(config.get("flags", ""))
         LOG.info("Using flags: %s", str(self.flags))
         self._decoder = MessageDecode()
-        self.encoder = MessageEncode(self.flags.get("tx_count", 0))
+        self.encoder = MessageEncode(self.flags.get("tx_count", 1))
 
         self.loop = loop if loop else asyncio.get_event_loop()
         self._config = config
@@ -51,7 +51,7 @@ class UpbPim:
         url = self._config["url"]
         LOG.info("Connecting to UPB PIM at %s", url)
         scheme, dest, param = parse_url(url)
-        heartbeat_time = self.flags.get("heartbeat", 90) if scheme == "tcp" else -1
+        heartbeat_time = self.flags.get("heartbeat_timeout_sec", 90) if scheme == "tcp" else -1
         conn = partial(
             Connection,
             self.loop,


### PR DESCRIPTION
tx count of 2 seems to be required for the devices on my network to respond.
I don't know for sure, but I suspect it is related to the presence of a repeater. 
I found this oblique reference in the some [repeater documentation](https://www.smarthome-products.com/productspecs/HAI/39A00-3_Manual.pdf) that corroborates this theory:

> UPStart normally uses uni-packet transmissions to communicate to UPB™ devices however, once the TPR is added to the network, it will automatically switch to using multi-packet transmissions. UPStart indicates that it has switched to two-time multi-packets by displaying TX=2 in the status bar. 

While I was at it, I also added the ability to configure the heartbeat timeout for TCP as requested in #5. It was also triggering for me spuriously.

Closes #5 