### PR TITLE
Promote tx_count to a first-class option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ are supported: `serial://<device>` where `<device>` is the serial/USB port on wh
 
 `UPStartExportFile`: the path of where to read the export file generated through File->Export on the UpStart utility. This is optional but recommended.
 
-`flags`: A string that contains a set of comma separated flags. Each flag can take the form of <flag_name> or <flag_name>=<value>. Parse is simple with no escapes. So, values cannot contain commas or equals. Flags supported are:
+`tx_count`: (optional) The number of times every UPB message is transmitted (CNT portion of the control word). Defaults to 1. Setting the value to 2 may be required for networks that use a repeater.
+
+`flags`: (optional) A string that contains a set of comma separated flags. Each flag can take the form of <flag_name> or <flag_name>=<value>. Parse is simple with no escapes. So, values cannot contain commas or equals. Flags supported are:
 
 - `unlimited_blink_rate`: By default the minimum value that can be pass to blink a light or link is 30 (which is about 1/2 a second). When this flag is specified the minimum is 1.
 - `use_raw_rate`: By default the API takes the number of seconds as the rate in which to transition lights to their new level. The number of seconds is coverted to the closest rate value that UPB understands (see rate table below). For example, if a request is to transition a light to its new state in 8 seconds, the closest value that UPB supports is 6.6 seconds and that is the transition time that will be used. If the use raw rate flag is given on initializing this library then the rate value is assumed to be the UPB rate value. i.e.: not in seconds but is a value that UPB "understands".
 - `report_state`: By default the API does not ask for a state update from a device when issuing goto, fade start, or blink commands. Including this flag on startup of the library will cause a report state to be issued immediately following one of the mentioned state changing commands.
 - `no_sync`: By default when the library first starts a report state is sent to every device to synchronize the state of the UPB network with the library. This flag turns off the initial sync. This was put in place for debugging and is not expected to be used outside of that.
 - `heartbeat_timeout_sec`: Overrides the duration of idleness (no messages being received) after which the library will re-initialize the connection, possibly triggering a sync. Applies only to the `tcp` protocol, and defaults to 90 seconds. Setting the value to -1 disables this feature.
-- `tx_count`: The number of times every UPB message is transmitted (CNT portion of the control word). Defaults to 1. Setting the value to 2 may be required for networks that use a repeater.
 
 ## First use of the API
 

--- a/upb_lib/message.py
+++ b/upb_lib/message.py
@@ -83,15 +83,15 @@ class MessageEncode:
 
     def __init__(self, tx_count):
         """Initialize a new MessageEncode instance."""
-        # Value of 00 corresponds to 1 transmit.
-        self._tx_count = tx_count - 1
+        self.tx_count = tx_count
 
     def _create_control_word(self, link, repeater=0, ack=0):
         """Create a control word in UPB message."""
         ctl = (1 if link else 0) << 15
         ctl = ctl | (repeater << 13)
         ctl = ctl | (ack << 4)
-        ctl = ctl | (self._tx_count << 2)
+        # Value of 00 corresponds to 1 transmit.
+        ctl = ctl | (self.tx_count - 1 << 2)
         ctl = ctl | 0
         return ctl
 

--- a/upb_lib/upb.py
+++ b/upb_lib/upb.py
@@ -25,7 +25,7 @@ class UpbPim:
         self.flags = parse_flags(config.get("flags", ""))
         LOG.info("Using flags: %s", str(self.flags))
         self._decoder = MessageDecode()
-        self.encoder = MessageEncode(self.flags.get("tx_count", 1))
+        self.encoder = MessageEncode(config.get("tx_count", 1))
 
         self.loop = loop if loop else asyncio.get_event_loop()
         self._config = config


### PR DESCRIPTION
This will make it possible to configure the tx_count from HA without reinitializing the PIM, or accessing private state.

In addition to making encoder tx_count public, I'm also still taking tx_count as a constructor parameter to the PIM -- this is because, as far as I understand the code, PIM's loop starts running before the constructor terminates, and it should have the "correct" tx_count value.